### PR TITLE
Add LUA NPC reputation system

### DIFF
--- a/data/npc/lib/npcsystem/modules.lua
+++ b/data/npc/lib/npcsystem/modules.lua
@@ -1,7 +1,8 @@
 -- Advanced NPC System by Jiddo
 
 if not Modules then
-	-- default words for greeting and ungreeting the npc. Should be a table containing all such words.
+    dofile('data/npc/lib/reputation.lua')
+        -- default words for greeting and ungreeting the npc. Should be a table containing all such words.
 	FOCUS_GREETWORDS = {"hi", "hello"}
 	FOCUS_FAREWELLWORDS = {"bye", "farewell"}
 
@@ -976,13 +977,16 @@ if not Modules then
 			totalCost = ItemType(itemid):isStackable() and totalCost + 20 or totalCost + (math.max(1, math.floor(amount / ItemType(ITEM_SHOPPING_BAG):getCapacity())) * 20)
 		end
 
-		local player = Player(cid)
-		local parseInfo = {
-			[TAG_PLAYERNAME] = player:getName(),
-			[TAG_ITEMCOUNT] = amount,
-			[TAG_TOTALCOST] = totalCost,
-			[TAG_ITEMNAME] = shopItem.name
-		}
+                local player = Player(cid)
+                local npcName = Npc():getName()
+                totalCost = math.floor(totalCost * Reputation.priceModifier(player, npcName))
+                Reputation.add(player, npcName)
+                local parseInfo = {
+                        [TAG_PLAYERNAME] = player:getName(),
+                        [TAG_ITEMCOUNT] = amount,
+                        [TAG_TOTALCOST] = totalCost,
+                        [TAG_ITEMNAME] = shopItem.name
+                }
 
 		if player:getTotalMoney() < totalCost then
 			local msg = self.npcHandler:getMessage(MESSAGE_NEEDMONEY)

--- a/data/npc/lib/npcsystem/npchandler.lua
+++ b/data/npc/lib/npcsystem/npchandler.lua
@@ -1,7 +1,8 @@
 -- Advanced NPC System by Jiddo
 
 if not NpcHandler then
-	-- Constant talkdelay behaviors.
+    dofile('data/npc/lib/reputation.lua')
+        -- Constant talkdelay behaviors.
 	TALKDELAY_NONE = 0 -- No talkdelay. Npc will reply immedeatly.
 	TALKDELAY_ONTHINK = 1 -- Talkdelay handled through the onThink callback function. (Default)
 	TALKDELAY_EVENT = 2 -- Not yet implemented
@@ -326,8 +327,8 @@ if not NpcHandler then
 				local playerName = player and player:getName() or -1
 				local parseInfo = { [TAG_PLAYERNAME] = playerName }
 				self:resetNpc(cid)
-				msg = self:parseMessage(msg, parseInfo)
-				self:say(msg, cid, true)
+                                        msg = self:parseMessage(msg, parseInfo)
+                                        self:say(msg, cid, true)
 				self:releaseFocus(cid)
 			end
 		end
@@ -343,9 +344,11 @@ if not NpcHandler then
 					local player = Player(cid)
 					local playerName = player and player:getName() or -1
 					local parseInfo = { [TAG_PLAYERNAME] = playerName }
-					msg = self:parseMessage(msg, parseInfo)
-					self:say(msg, cid, true)
-				else
+                                        msg = self:parseMessage(msg, parseInfo)
+                                        self:say(msg, cid, true)
+                                        local npcName = Npc():getName()
+                                        Reputation.handleGreet(player, npcName)
+                                else
 					return
 				end
 			else

--- a/data/npc/lib/reputation.lua
+++ b/data/npc/lib/reputation.lua
@@ -1,0 +1,84 @@
+-- NPC Reputation System
+Reputation = Reputation or {}
+
+local configFile = 'data/npc/reputation_config.xml'
+
+-- default values
+Reputation.config = { gain = 1, discount = 10, gift = 20, quest = 30 }
+Reputation.storageBase = 200000
+
+local function loadValue(pattern, text, default)
+    local v = text:match(pattern)
+    if v then
+        return tonumber(v)
+    end
+    return default
+end
+
+function Reputation.load()
+    local f = io.open(configFile, 'r')
+    if not f then
+        print('[Warning] reputation_config.xml not found, using defaults.')
+        return
+    end
+    local data = f:read('*a')
+    f:close()
+    Reputation.config.gain = loadValue('gain="(%%d+)"', data, Reputation.config.gain)
+    Reputation.config.discount = loadValue('name="discount"%s+value="(%%d+)"', data, Reputation.config.discount)
+    Reputation.config.gift = loadValue('name="gift"%s+value="(%%d+)"', data, Reputation.config.gift)
+    Reputation.config.quest = loadValue('name="quest"%s+value="(%%d+)"', data, Reputation.config.quest)
+end
+
+local function hash(name)
+    local h = 0
+    for i = 1, #name do
+        h = h + name:byte(i)
+    end
+    return h
+end
+
+function Reputation.getKey(name)
+    return Reputation.storageBase + hash(name)
+end
+
+function Reputation.add(player, name)
+    local key = Reputation.getKey(name)
+    local rep = player:getStorageValue(key)
+    if rep < 0 then rep = 0 end
+    rep = rep + Reputation.config.gain
+    player:setStorageValue(key, rep)
+    return rep
+end
+
+function Reputation.get(player, name)
+    local key = Reputation.getKey(name)
+    local rep = player:getStorageValue(key)
+    if rep < 0 then return 0 end
+    return rep
+end
+
+function Reputation.priceModifier(player, name)
+    local rep = Reputation.get(player, name)
+    if rep >= Reputation.config.discount then
+        return 0.8 -- 20% discount
+    end
+    return 1
+end
+
+function Reputation.handleGreet(player, name)
+    local rep = Reputation.add(player, name)
+    local key = Reputation.getKey(name)
+    if rep >= Reputation.config.gift and player:getStorageValue(key + 1) ~= 1 then
+        player:addItem(2152, 10) -- 10 platinum coins
+        player:setStorageValue(key + 1, 1)
+        Npc():say('You have helped me a lot, take this small gift.', player)
+    elseif rep >= Reputation.config.quest and player:getStorageValue(key + 2) ~= 1 then
+        Npc():say('I have a rare quest for you when you are ready.', player)
+        player:setStorageValue(key + 2, 1)
+    elseif rep >= Reputation.config.discount then
+        Npc():say('My prices are cheaper for you now.', player)
+    end
+end
+
+Reputation.load()
+return Reputation

--- a/data/npc/reputation_config.xml
+++ b/data/npc/reputation_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<reputation gain="1">
+    <threshold name="discount" value="10" />
+    <threshold name="gift" value="20" />
+    <threshold name="quest" value="30" />
+</reputation>

--- a/docs/npc_reputation.md
+++ b/docs/npc_reputation.md
@@ -1,0 +1,61 @@
+# NPC Reputation System
+
+This project includes a Lua based reputation system that allows NPCs to track how much each player has interacted with them. Gaining reputation unlocks cheaper shop prices, small gifts and access to special quests.
+
+## Overview
+
+- **Library:** `data/npc/lib/reputation.lua`
+- **Configuration:** `data/npc/reputation_config.xml`
+- **NPC Integration:** modifications in `data/npc/lib/npcsystem/modules.lua` and `data/npc/lib/npcsystem/npchandler.lua`
+
+The reputation library is loaded automatically when NPC scripts are executed. Each NPC shares the same configuration but tracks reputation for players individually.
+
+### XML Configuration
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<reputation gain="1">
+    <threshold name="discount" value="10" />
+    <threshold name="gift" value="20" />
+    <threshold name="quest" value="30" />
+</reputation>
+```
+
+- **gain** – amount of reputation awarded each time a player interacts with an NPC (greet or trade).
+- **threshold "discount"** – reputation required before shop prices are reduced by 20%.
+- **threshold "gift"** – reputation required for the NPC to give a small reward (10 platinum coins).
+- **threshold "quest"** – reputation required before the NPC offers a unique quest.
+
+Adjust these values to tune your server. The configuration is loaded when the server starts.
+
+### Reputation Storage
+
+Reputation values are stored in player storage. A unique storage key is derived from the NPC name, ensuring each NPC keeps its own reputation score for every player. Reputation increases when:
+
+1. A player greets an NPC for the first time in a session.
+2. A player completes a shop transaction.
+
+The `priceModifier` function in the library applies the discount once the threshold is reached.
+
+### Gift and Quest Unlocks
+
+When a player reaches the `gift` threshold, the NPC automatically hands out 10 platinum coins (once). At the `quest` threshold the NPC informs the player about a rare quest. These checks occur when greeting the NPC.
+
+### Adding New Behavior
+
+Developers can call the functions exposed by the library from any NPC script:
+
+- `Reputation.add(player, npcName)` – increase the player's reputation with the NPC.
+- `Reputation.get(player, npcName)` – read the current reputation value.
+- `Reputation.priceModifier(player, npcName)` – return 0.8 if the player receives a discount, otherwise 1.
+
+Feel free to expand the library with additional rewards or NPC dialogue.
+
+## Usage
+
+1. Place `reputation.lua` in `data/npc/lib/` and `reputation_config.xml` in `data/npc/`.
+2. Ensure NPC scripts include the modified `modules.lua` and `npchandler.lua` from this repository.
+3. Restart the server. NPCs will automatically grant reputation when greeted or when a purchase is made.
+
+Players can improve relations with any NPC simply by interacting with them. Over time they will receive discounts, small gifts and special quests based on the thresholds you configure.
+


### PR DESCRIPTION
## Summary
- implement reputation library for NPCs
- load reputation config from XML
- update npc system libraries to award reputation on greet and adjust shop prices
- document the NPC reputation system in docs/npc_reputation.md

## Testing
- `luac -p data/npc/lib/reputation.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875bff29c24833282962ac0a6f2c07a