### PR TITLE
Add configurable weapon craft attributes

### DIFF
--- a/data/npc/scripts/weapon_crafter.lua
+++ b/data/npc/scripts/weapon_crafter.lua
@@ -4,6 +4,7 @@ NpcSystem.parseParameters(npcHandler)
 
 local Handler = dofile('data/scripts/crafting/handler.lua')
 dofile('data/scripts/crafting/recipes/weapons.lua')
+dofile('data/scripts/crafting/attribute_config.lua')
 
 local crafting = Handler.create(npcHandler, weaponRecipes, PlayerStorageKeys.weaponsmithSkill)
 

--- a/data/scripts/crafting/attribute_config.lua
+++ b/data/scripts/crafting/attribute_config.lua
@@ -1,0 +1,35 @@
+-- Default chances for weapon attributes when crafting
+-- id = percentage chance to apply
+
+WeaponAttributeConfig = {
+    [1] = 5,  -- Armor Penetration
+    [2] = 4,  -- Block Chance
+    [3] = 4,  -- Parry Chance
+    [4] = 3,  -- Dodge Chance
+    [5] = 2,  -- Reflect Damage
+    [6] = 3,  -- True Damage
+    [7] = 2,  -- Bleed Chance
+    [8] = 1,  -- Execution Chance
+    [9] = 2,  -- Knockback Strength
+    [10] = 1, -- Stun Chance
+    [11] = 3, -- Spell Power
+    [12] = 3, -- Mana Efficiency
+    [13] = 2, -- Silence Resistance
+    [14] = 1, -- Holy Vulnerability
+    [15] = 2, -- Elemental Surge Chance
+    [16] = 2, -- Curse Resistance
+    [17] = 1, -- Chaos Affinity
+    [18] = 2, -- Weight Reduction
+    [19] = 4, -- XP Gain Bonus
+    [20] = 2, -- Loot Drop Bonus
+    [21] = 2, -- Trap Resistance
+    [22] = 3, -- Aggro Modifier
+    [23] = 1, -- Jump Distance
+    [24] = 2, -- Auto Heal Chance
+    [25] = 2, -- Status Duration Reduction
+    [26] = 1, -- Pet Damage Bonus
+    [27] = 3, -- Crafting Mastery
+    [28] = 1, -- Night Vision
+    [29] = 2, -- Burning Aura
+    [30] = 2  -- Resourceful
+}

--- a/data/scripts/crafting/handler.lua
+++ b/data/scripts/crafting/handler.lua
@@ -87,7 +87,16 @@ function Handler.create(npcHandler, recipes, storage)
                     player:removeMoney(recipe.cost)
                 end
                 if math.random(100) <= chance then
-                    player:addItem(recipe.result, 1)
+                    local newItem = player:addItem(recipe.result, 1)
+                    -- load attribute chance configuration and roll for bonuses
+                    dofile('data/scripts/crafting/attribute_config.lua')
+                    if newItem and WeaponAttributeConfig then
+                        for id, pct in pairs(WeaponAttributeConfig) do
+                            if math.random(100) <= pct then
+                                newItem:setCustomAttribute(id, pct)
+                            end
+                        end
+                    end
                     Crafting.addSkillPoint(player, self.storage)
                     self.npcHandler:say("Success! Here is your " .. ItemType(recipe.result):getName() .. ".", cid)
                 else

--- a/docs/custom_attributes.md
+++ b/docs/custom_attributes.md
@@ -51,3 +51,14 @@ Scripts may access the definitions as follows:
 local name = CustomAttributes.getName(1) -- "Armor Penetration"
 local desc = CustomAttributes.getDescription(1)
 local group = CustomAttributes.getGroup(1)
+```
+
+### Crafting Attribute Chances
+
+Weapon crafting uses `data/scripts/crafting/attribute_config.lua` to determine
+which custom attributes may be applied to a newly created item.  The file
+defines a table `WeaponAttributeConfig` where each key is an attribute id and
+the value is the percentage chance that attribute will be rolled.
+
+Adjust the numbers in the table to make certain bonuses more or less common.
+A value of `0` disables an attribute entirely.


### PR DESCRIPTION
## Summary
- create `WeaponAttributeConfig` with default chances
- apply attributes to crafted items in handler
- load config in weapon_crafter NPC script
- document how to tune chances

## Testing
- `luac` not available, unable to run Lua syntax checks

------
https://chatgpt.com/codex/tasks/task_e_6875e81ae72c83328aa82847785eac72