### PR TITLE
Add custom attribute info to onLook description

### DIFF
--- a/data/scripts/eventcallbacks/player/default_onLook.lua
+++ b/data/scripts/eventcallbacks/player/default_onLook.lua
@@ -1,9 +1,17 @@
 local event = Event()
 
 event.onLook = function(self, thing, position, distance, description)
-	local description = "You see " .. thing:getDescription(distance)
-	if self:getGroup():getAccess() then
-		if thing:isItem() then
+        local description = "You see " .. thing:getDescription(distance)
+        if thing:isItem() then
+                for id, _ in pairs(CustomAttributes.attributes) do
+                        local value = thing:getCustomAttribute(id)
+                        if value ~= nil then
+                                description = string.format("%s\n%s: %s", description, CustomAttributes.getName(id), tostring(value))
+                        end
+                end
+        end
+        if self:getGroup():getAccess() then
+                if thing:isItem() then
 			description = string.format("%s\nItem ID: %d", description, thing:getId())
 
 			local actionId = thing:getActionId()


### PR DESCRIPTION
## Summary
- enhance player look callback to include item custom attributes

## Testing
- `luacheck --version` *(fails: command not found)*
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875ee5393e48332b1f8862587ad3feb