### PR TITLE
Add custom attribute equip handlers

### DIFF
--- a/data/movements/movements.xml
+++ b/data/movements/movements.xml
@@ -1440,4 +1440,21 @@
 	<movevent event="DeEquip" itemid="25411" slot="shield" function="onDeEquipItem" />
 	<movevent event="Equip" itemid="25414" slot="shield" level="200" function="onEquipItem" />
 	<movevent event="DeEquip" itemid="25414" slot="shield" function="onDeEquipItem" />
+        <!-- Custom attribute handlers -->
+        <movevent event="Equip" fromid="1" toid="30000" slot="head" script="apply_custom_attributes.lua" />
+        <movevent event="DeEquip" fromid="1" toid="30000" slot="head" script="apply_custom_attributes.lua" />
+        <movevent event="Equip" fromid="1" toid="30000" slot="necklace" script="apply_custom_attributes.lua" />
+        <movevent event="DeEquip" fromid="1" toid="30000" slot="necklace" script="apply_custom_attributes.lua" />
+        <movevent event="Equip" fromid="1" toid="30000" slot="armor" script="apply_custom_attributes.lua" />
+        <movevent event="DeEquip" fromid="1" toid="30000" slot="armor" script="apply_custom_attributes.lua" />
+        <movevent event="Equip" fromid="1" toid="30000" slot="legs" script="apply_custom_attributes.lua" />
+        <movevent event="DeEquip" fromid="1" toid="30000" slot="legs" script="apply_custom_attributes.lua" />
+        <movevent event="Equip" fromid="1" toid="30000" slot="feet" script="apply_custom_attributes.lua" />
+        <movevent event="DeEquip" fromid="1" toid="30000" slot="feet" script="apply_custom_attributes.lua" />
+        <movevent event="Equip" fromid="1" toid="30000" slot="ring" script="apply_custom_attributes.lua" />
+        <movevent event="DeEquip" fromid="1" toid="30000" slot="ring" script="apply_custom_attributes.lua" />
+        <movevent event="Equip" fromid="1" toid="30000" slot="hand" script="apply_custom_attributes.lua" />
+        <movevent event="DeEquip" fromid="1" toid="30000" slot="hand" script="apply_custom_attributes.lua" />
+        <movevent event="Equip" fromid="1" toid="30000" slot="shield" script="apply_custom_attributes.lua" />
+        <movevent event="DeEquip" fromid="1" toid="30000" slot="shield" script="apply_custom_attributes.lua" />
 </movements>

--- a/data/scripts/movements/apply_custom_attributes.lua
+++ b/data/scripts/movements/apply_custom_attributes.lua
@@ -1,0 +1,27 @@
+function onEquipCustomAttributes(player, item, slot, isCheck)
+    if isCheck then
+        return true
+    end
+    for id, _ in pairs(CustomAttributes.attributes) do
+        local value = item:getCustomAttribute(id)
+        if value then
+            local current = player:getCustomAttribute(id)
+            player:setCustomAttribute(id, current + value)
+        end
+    end
+    return true
+end
+
+function onDeEquipCustomAttributes(player, item, slot, isCheck)
+    if isCheck then
+        return true
+    end
+    for id, _ in pairs(CustomAttributes.attributes) do
+        local value = item:getCustomAttribute(id)
+        if value then
+            local current = player:getCustomAttribute(id)
+            player:setCustomAttribute(id, current - value)
+        end
+    end
+    return true
+end


### PR DESCRIPTION
## Summary
- add script to adjust player custom attributes when equipping items
- register script for all equipment slots

## Testing
- `luac` not available and repository has no automated tests


------
https://chatgpt.com/codex/tasks/task_e_6875efae947c8332b3f2e2bd67f4c686