### PR TITLE
Fix custom attribute event names

### DIFF
--- a/data/creaturescripts/creaturescripts.xml
+++ b/data/creaturescripts/creaturescripts.xml
@@ -9,7 +9,7 @@
         <event type="death" name="DropLoot" script="drop_loot.lua" />
         <event type="extendedopcode" name="ExtendedOpcode" script="extended_opcode.lua" />
         <event type="login" name="CustomAttributes" script="custom_attributes.lua" />
-        <event type="think" name="CustomAttributes" script="custom_attributes.lua" />
-        <event type="healthchange" name="CustomAttributes" script="custom_attributes.lua" />
-        <event type="manachange" name="CustomAttributes" script="custom_attributes.lua" />
+        <event type="think" name="CustomAttributesThink" script="custom_attributes.lua" />
+        <event type="healthchange" name="CustomAttributesHealth" script="custom_attributes.lua" />
+        <event type="manachange" name="CustomAttributesMana" script="custom_attributes.lua" />
 </creaturescripts>


### PR DESCRIPTION
## Summary
- fix mismatched event names for custom attributes in `creaturescripts.xml`
- ensure login registers the corresponding names for think, health, and mana events

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6875f55ef6348332a5c91e07c528c0cc