### PR TITLE
Integrate gate manager into game loop

### DIFF
--- a/docs/gate_system.md
+++ b/docs/gate_system.md
@@ -47,14 +47,12 @@ Each `Gate` object tracks the portal state and its associated instance.
 
 ### Integration Notes
 
-Currently the system is self‑contained and does not automatically run. To integrate it you will need to:
+The server now calls `GateManager::update()` every tick from the main game loop, so gates expire automatically. You can control gates from Lua using:
 
-1. Create an update event that calls `GateManager::update()` periodically.
-2. Call `GateManager::spawnGate()` from gameplay scripts or NPCs to create new gates.
-3. Provide a Lua function `onGateBreak(gate)` inside `data/scripts/gate/` if you want to execute custom logic when a gate shatters. Use the `GateBreakWaves` table to list which monsters should spawn for each rank.
-4. Flesh out the `Instance` class and dungeon logic referenced by the `Gate` objects.
+1. `Game.spawnGate(position, rank[, type])` – returns the created gate id.
+2. `Game.removeGate(id)` – immediately deletes the gate.
 
-Once these pieces are in place the gate system can handle timed dungeon portals that expire if players fail to clear them in time.
+Still provide an `onGateBreak(gate)` function inside `data/scripts/gate/` if you want custom logic when a gate shatters. Use the `GateBreakWaves` table to list which monsters should spawn for each rank. The `Instance` class and dungeon logic are still experimental and need to be fleshed out.
 
 ### Lua Hook Example
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -27,6 +27,7 @@
 #include "scheduler.h"
 #include "script.h"
 #include "server.h"
+#include "gatemanager.h"
 #include "spectators.h"
 #include "spells.h"
 #include "storeinbox.h"
@@ -80,9 +81,13 @@ void Game::start(ServiceManager* manager) {
 		updateCreaturesPath(0);
 	}));
 
-	g_scheduler.addEvent(createSchedulerTask(EVENT_DECAYINTERVAL, [this]() {
-		checkDecay();
-	}));
+        g_scheduler.addEvent(createSchedulerTask(EVENT_DECAYINTERVAL, [this]() {
+                checkDecay();
+        }));
+
+        g_scheduler.addEvent(createSchedulerTask(EVENT_GATEINTERVAL, [this]() {
+                updateGates();
+        }));
 
 }
 
@@ -3694,7 +3699,15 @@ void Game::checkCreatures(size_t index) {
 		}
 	}
 
-	cleanup();
+        cleanup();
+}
+
+void Game::updateGates() {
+        g_scheduler.addEvent(createSchedulerTask(EVENT_GATEINTERVAL, [this]() {
+                updateGates();
+        }));
+
+        g_gateManager.update();
 }
 
 void Game::updateCreaturesPath(size_t index) {

--- a/src/game.h
+++ b/src/game.h
@@ -46,6 +46,7 @@ static constexpr int32_t EVENT_LIGHTINTERVAL = 10000;
 static constexpr int32_t EVENT_WORLDTIMEINTERVAL = 2500;
 static constexpr int32_t EVENT_DECAYINTERVAL = 250;
 static constexpr int32_t EVENT_DECAY_BUCKETS = 4;
+static constexpr int32_t EVENT_GATEINTERVAL = 1000;
 
 static constexpr int32_t MOVE_CREATURE_INTERVAL = 1000;
 
@@ -434,8 +435,9 @@ class Game {
 		void checkCreatureWalk(uint32_t creatureId);
 		void updateCreatureWalk(uint32_t creatureId);
 		void checkCreatureAttack(uint32_t creatureId);
-		void checkCreatures(size_t index);
-		void updateCreaturesPath(size_t index);
+                void checkCreatures(size_t index);
+                void updateGates();
+                void updateCreaturesPath(size_t index);
 		void checkLight();
 
 		bool combatBlockHit(CombatDamage& damage, Creature* attacker, Creature* target, bool checkDefense, bool checkArmor, bool field, bool ignoreResistances = false);

--- a/src/gatemanager.h
+++ b/src/gatemanager.h
@@ -17,4 +17,6 @@ class GateManager {
 		std::map<uint32_t, Gate> gates;
 };
 
+extern GateManager g_gateManager;
+
 #endif // FS_GATEMANAGER_H

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -1889,9 +1889,20 @@ void LuaScriptInterface::registerFunctions() {
 	registerEnum(L, WEAPON_WAND)
 	registerEnum(L, WEAPON_AMMO)
 
-	registerEnum(L, WORLD_TYPE_NO_PVP)
-	registerEnum(L, WORLD_TYPE_PVP)
-	registerEnum(L, WORLD_TYPE_PVP_ENFORCED)
+        registerEnum(L, WORLD_TYPE_NO_PVP)
+        registerEnum(L, WORLD_TYPE_PVP)
+        registerEnum(L, WORLD_TYPE_PVP_ENFORCED)
+
+        registerEnum(L, GateRank::E)
+        registerEnum(L, GateRank::D)
+        registerEnum(L, GateRank::C)
+        registerEnum(L, GateRank::B)
+        registerEnum(L, GateRank::A)
+        registerEnum(L, GateRank::S)
+
+        registerEnum(L, GateType::NORMAL)
+        registerEnum(L, GateType::RED)
+        registerEnum(L, GateType::DOUBLE)
 
 	// Use with container:addItem, container:addItemEx and possibly other functions.
 	registerEnum(L, FLAG_NOLIMIT)
@@ -2224,7 +2235,10 @@ void LuaScriptInterface::registerFunctions() {
 	registerMethod(L, "Game", "createMonster", LuaScriptInterface::luaGameCreateMonster);
 	registerMethod(L, "Game", "createNpc", LuaScriptInterface::luaGameCreateNpc);
 	registerMethod(L, "Game", "createTile", LuaScriptInterface::luaGameCreateTile);
-	registerMethod(L, "Game", "createMonsterType", LuaScriptInterface::luaGameCreateMonsterType);
+        registerMethod(L, "Game", "createMonsterType", LuaScriptInterface::luaGameCreateMonsterType);
+
+        registerMethod(L, "Game", "spawnGate", LuaScriptInterface::luaGameSpawnGate);
+        registerMethod(L, "Game", "removeGate", LuaScriptInterface::luaGameRemoveGate);
 
 	registerMethod(L, "Game", "startEvent", LuaScriptInterface::luaGameStartEvent);
 
@@ -4816,10 +4830,32 @@ int LuaScriptInterface::luaGameSetAccountStorageValue(lua_State* L) {
 }
 
 int LuaScriptInterface::luaGameSaveAccountStorageValues(lua_State* L) {
-	// Game.saveAccountStorageValues()
-	lua_pushboolean(L, g_game.saveAccountStorageValues());
+        // Game.saveAccountStorageValues()
+        lua_pushboolean(L, g_game.saveAccountStorageValues());
 
-	return 1;
+        return 1;
+}
+
+int LuaScriptInterface::luaGameSpawnGate(lua_State* L) {
+        // Game.spawnGate(position, rank[, type])
+        Position position = lua::getPosition(L, 1);
+        GateRank rank = lua::getNumber<GateRank>(L, 2);
+        GateType type = lua::getNumber<GateType>(L, 3, GateType::NORMAL);
+
+        Gate* gate = g_gateManager.spawnGate(position, rank, type);
+        if (gate) {
+                lua_pushnumber(L, gate->getId());
+        } else {
+                lua_pushnil(L);
+        }
+        return 1;
+}
+
+int LuaScriptInterface::luaGameRemoveGate(lua_State* L) {
+        // Game.removeGate(id)
+        uint32_t id = lua::getNumber<uint32_t>(L, 1);
+        g_gateManager.removeGate(id);
+        return 0;
 }
 
 // Variant

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -330,7 +330,10 @@ class LuaScriptInterface {
 
 		static int luaGameGetAccountStorageValue(lua_State* L);
 		static int luaGameSetAccountStorageValue(lua_State* L);
-		static int luaGameSaveAccountStorageValues(lua_State* L);
+                static int luaGameSaveAccountStorageValues(lua_State* L);
+
+                static int luaGameSpawnGate(lua_State* L);
+                static int luaGameRemoveGate(lua_State* L);
 
 		// Variant
 		static int luaVariantCreate(lua_State* L);

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -20,6 +20,7 @@
 #include "script.h"
 #include "scriptmanager.h"
 #include "server.h"
+#include "gatemanager.h"
 
 #include <fstream>
 
@@ -34,6 +35,7 @@ Scheduler g_scheduler;
 Game g_game;
 Monsters g_monsters;
 Vocations g_vocations;
+GateManager g_gateManager;
 extern Scripts* g_scripts;
 
 std::mutex g_loaderLock;


### PR DESCRIPTION
## Summary
- hook GateManager into the main Game loop
- provide Lua bindings `Game.spawnGate` and `Game.removeGate`
- expose Gate enums to Lua
- document automatic gate updates and scripting functions

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "fmt")*

------
https://chatgpt.com/codex/tasks/task_e_68760cda30988332bbcf9aa8b1bd06a0