### PR TITLE
Fix enum registration with Lua

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -1107,8 +1107,14 @@ static void pushLoot(lua_State* L, const std::vector<LootBlock>& lootList) {
 	}
 }
 
-#define registerEnum(L, value) {std::string enumName = #value; registerGlobalVariable(L, enumName.substr(enumName.find_last_of(':') + 1), value); }
-#define registerEnumIn(L, tableName, value) { std::string enumName = #value; registerVariable(L, tableName, enumName.substr(enumName.find_last_of(':') + 1), value); }
+#define registerEnum(L, value) { \
+    std::string enumName = #value; \
+    registerGlobalVariable(L, enumName.substr(enumName.find_last_of(':') + 1), static_cast<lua_Number>(value)); \
+}
+#define registerEnumIn(L, tableName, value) { \
+    std::string enumName = #value; \
+    registerVariable(L, tableName, enumName.substr(enumName.find_last_of(':') + 1), static_cast<lua_Number>(value)); \
+}
 
 void LuaScriptInterface::registerFunctions() {
 	using namespace lua;


### PR DESCRIPTION
## Summary
- fix compile error when registering enums with Lua by casting to `lua_Number`

## Testing
- `cmake -S . -B build` *(fails: Could not find package fmt)*

------
https://chatgpt.com/codex/tasks/task_e_687611bfe2788332ba34a2f06e23218c