### PR TITLE
Add gate spawn configuration

### DIFF
--- a/data/global.lua
+++ b/data/global.lua
@@ -1,5 +1,6 @@
 math.randomseed(os.time())
 dofile('data/lib/lib.lua')
+dofile('data/scripts/gate/spawn_config.lua')
 
 ropeSpots = {
 	384, 418, 8278, 8592, 13189, 14435, 14436, 14857, 15635, 19518, 24621, 24622, 24623, 24624, 26019

--- a/data/scripts/gate/spawn_config.lua
+++ b/data/scripts/gate/spawn_config.lua
@@ -1,10 +1,9 @@
--- Example gate spawn configuration
 GateSpawnConfig = {
     center = {x = 1000, y = 1000, z = 7},
     radius = 25,
-    interval = 60000,
-    rules = {
-        {rank = GateRank.E, type = GateType.NORMAL, max = 2},
-        {rank = GateRank.D, type = GateType.RED,    max = 1}
+    interval = 5 * 60 * 1000, -- milliseconds
+    gates = {
+        {rank = GateRank.E, type = GateType.NORMAL, count = 2},
+        {rank = GateRank.D, type = GateType.NORMAL, count = 1},
     }
 }

--- a/docs/gate_spawner.md
+++ b/docs/gate_spawner.md
@@ -7,11 +7,11 @@ from `data/scripts/gate/spawn_config.lua`.
 ```lua
 GateSpawnConfig = {
     center = {x = 1000, y = 1000, z = 7},
-    radius = 25,      -- tiles around the center
-    interval = 60000, -- milliseconds between spawn checks
-    rules = {
-        {rank = GateRank.E, type = GateType.NORMAL, max = 2},
-        {rank = GateRank.D, type = GateType.RED,    max = 1}
+    radius = 25,            -- tiles around the center
+    interval = 5 * 60 * 1000, -- milliseconds
+    gates = {
+        {rank = GateRank.E, type = GateType.NORMAL, count = 2},
+        {rank = GateRank.D, type = GateType.NORMAL, count = 1},
     }
 }
 ```
@@ -19,10 +19,10 @@ GateSpawnConfig = {
 * **center** – world position used as the spawner origin.
 * **radius** – distance from the center in which gates may appear.
 * **interval** – time in milliseconds between spawn attempts.
-* **rules** – list describing what gates can spawn. Each rule contains:
+* **gates** – list describing what gates can spawn. Each entry contains:
   * `rank` – gate rank to spawn.
   * `type` – gate type.
-  * `max`  – maximum number of gates of this rank/type that may exist.
+  * `count` – how many gates of this rank/type should exist.
 
 The server checks every `interval` and spawns new gates inside the
-`radius` when fewer than `max` are present.
+`radius` when fewer than the specified `count` are present.


### PR DESCRIPTION
## Summary
- load gate spawn config from `global.lua`
- document gate spawner table format
- define `GateSpawnConfig` example

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6876c84e46108332b62c629473144930