### PR TITLE
Add onGateRemoved Lua hook

### DIFF
--- a/docs/gate_system.md
+++ b/docs/gate_system.md
@@ -41,7 +41,7 @@ Each `Gate` object tracks the portal state and its associated instance.
 `GateManager` owns all active gates and must be updated regularly.
 
 - `spawnGate(position, rank, type)` – Creates a gate at `position` with the given rank and type. The expiration time is derived from the rank.
-- `update()` – Should be called every server tick or on a timed event. It marks gates as expired when their timer elapses and removes them from the manager. When a gate breaks before being cleared it triggers the optional `onGateBreak` Lua hook and spawns monsters configured in `GateBreakWaves`.
+- `update()` – Should be called every server tick or on a timed event. It marks gates as expired when their timer elapses and removes them from the manager. When a gate breaks before being cleared it triggers the optional `onGateBreak` Lua hook and spawns monsters configured in `GateBreakWaves`. Whenever a gate is erased the optional `onGateRemoved` hook is called after its instance has been cleaned up.
 - `getGate(id)` – Returns a pointer to the stored `Gate` or `nullptr` if the ID is unknown.
 - `removeGate(id)` – Erases a gate immediately from the manager.
 
@@ -52,7 +52,7 @@ The server now calls `GateManager::update()` every tick from the main game loop,
 1. `Game.spawnGate(position, rank[, type])` – returns the created gate id.
 2. `Game.removeGate(id)` – immediately deletes the gate.
 
-Still provide an `onGateBreak(gate)` function inside `data/scripts/gate/` if you want custom logic when a gate shatters. Use the `GateBreakWaves` table to list which monsters should spawn for each rank. The `Instance` class and dungeon logic are still experimental and need to be fleshed out.
+Still provide `onGateBreak(gate)` and/or `onGateRemoved(gate)` functions inside `data/scripts/gate/` if you want custom logic when a gate shatters or is removed. Use the `GateBreakWaves` table to list which monsters should spawn for each rank. The `Instance` class and dungeon logic are still experimental and need to be fleshed out.
 
 ### Lua Hook Example
 
@@ -67,7 +67,11 @@ GateBreakWaves = {
 function onGateBreak(gate)
     print("Gate broke at", gate.position.x, gate.position.y, gate.position.z)
 end
+
+function onGateRemoved(gate)
+    print("Gate removed", gate.id)
+end
 ```
 
-`GateBreakWaves` defines the monsters spawned when a gate of the given rank collapses. The `onGateBreak` function is optional and can be extended to implement additional behavior.
+`GateBreakWaves` defines the monsters spawned when a gate of the given rank collapses. The `onGateBreak` and `onGateRemoved` functions are optional and can be extended to implement additional behavior.
 

--- a/src/gatemanager.cpp
+++ b/src/gatemanager.cpp
@@ -239,6 +239,36 @@ void GateManager::update()
                                 it->second.setInstance(nullptr);
                         }
                         g_game.map.removeTile(it->second.getPosition());
+
+                        lua_State* L = g_luaEnvironment.getLuaState();
+                        lua_getglobal(L, "onGateRemoved");
+                        if (lua_isfunction(L, -1)) {
+                                if (lua::reserveScriptEnv()) {
+                                        ScriptEnvironment* env = lua::getScriptEnv();
+                                        env->setScriptId(-1, &g_luaEnvironment);
+
+                                        lua_newtable(L);
+                                        lua_pushnumber(L, it->second.getId());
+                                        lua_setfield(L, -2, "id");
+                                        lua::pushPosition(L, it->second.getPosition());
+                                        lua_setfield(L, -2, "position");
+                                        lua_pushnumber(L, static_cast<int>(it->second.getRank()));
+                                        lua_setfield(L, -2, "rank");
+                                        lua_pushnumber(L, static_cast<int>(it->second.getType()));
+                                        lua_setfield(L, -2, "type");
+
+                                        if (lua_pcall(L, 1, 0, 0) != 0) {
+                                                std::cout << "[Warning - GateManager::update] onGateRemoved: " << lua_tostring(L, -1) << std::endl;
+                                                lua_pop(L, 1);
+                                        }
+                                        lua::resetScriptEnv();
+                                } else {
+                                        lua_pop(L, 1);
+                                }
+                        } else {
+                                lua_pop(L, 1);
+                        }
+
                         gates.erase(it);
                 }
         }
@@ -293,6 +323,36 @@ void GateManager::removeGate(uint32_t gateId)
                         delete inst;
                 }
                 g_game.map.removeTile(it->second.getPosition());
+
+                lua_State* L = g_luaEnvironment.getLuaState();
+                lua_getglobal(L, "onGateRemoved");
+                if (lua_isfunction(L, -1)) {
+                        if (lua::reserveScriptEnv()) {
+                                ScriptEnvironment* env = lua::getScriptEnv();
+                                env->setScriptId(-1, &g_luaEnvironment);
+
+                                lua_newtable(L);
+                                lua_pushnumber(L, it->second.getId());
+                                lua_setfield(L, -2, "id");
+                                lua::pushPosition(L, it->second.getPosition());
+                                lua_setfield(L, -2, "position");
+                                lua_pushnumber(L, static_cast<int>(it->second.getRank()));
+                                lua_setfield(L, -2, "rank");
+                                lua_pushnumber(L, static_cast<int>(it->second.getType()));
+                                lua_setfield(L, -2, "type");
+
+                                if (lua_pcall(L, 1, 0, 0) != 0) {
+                                        std::cout << "[Warning - GateManager::removeGate] onGateRemoved: " << lua_tostring(L, -1) << std::endl;
+                                        lua_pop(L, 1);
+                                }
+                                lua::resetScriptEnv();
+                        } else {
+                                lua_pop(L, 1);
+                        }
+                } else {
+                        lua_pop(L, 1);
+                }
+
                 gates.erase(it);
         }
 }


### PR DESCRIPTION
## Summary
- fire new Lua callback `onGateRemoved` when a gate is erased
- call the hook from both `update()` and `removeGate()`
- document the callback in gate system docs

## Testing
- `cmake -B build -S .` *(fails: Could not find fmt)*

------
https://chatgpt.com/codex/tasks/task_e_6876c9278ce08332b2a7553d043b3a23