### PR TITLE
Fix gate spawner startup errors

### DIFF
--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -37,6 +37,18 @@ SOUTHEAST = DIRECTION_SOUTHEAST
 NORTHWEST = DIRECTION_NORTHWEST
 NORTHEAST = DIRECTION_NORTHEAST
 
+-- Basic helper used by older scripts
+if not table.contains then
+    function table.contains(t, value)
+        for _, v in pairs(t) do
+            if v == value then
+                return true
+            end
+        end
+        return false
+    end
+end
+
 do
 	local function storageProxy(player)
 		return setmetatable({}, {

--- a/data/movements/scripts/apply_custom_attributes.lua
+++ b/data/movements/scripts/apply_custom_attributes.lua
@@ -1,0 +1,27 @@
+function onEquipCustomAttributes(player, item, slot, isCheck)
+    if isCheck then
+        return true
+    end
+    for id, _ in pairs(CustomAttributes.attributes) do
+        local value = item:getCustomAttribute(id)
+        if value then
+            local current = player:getCustomAttribute(id)
+            player:setCustomAttribute(id, current + value)
+        end
+    end
+    return true
+end
+
+function onDeEquipCustomAttributes(player, item, slot, isCheck)
+    if isCheck then
+        return true
+    end
+    for id, _ in pairs(CustomAttributes.attributes) do
+        local value = item:getCustomAttribute(id)
+        if value then
+            local current = player:getCustomAttribute(id)
+            player:setCustomAttribute(id, current - value)
+        end
+    end
+    return true
+end

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -1907,16 +1907,27 @@ void LuaScriptInterface::registerFunctions() {
         registerEnum(L, WORLD_TYPE_PVP)
         registerEnum(L, WORLD_TYPE_PVP_ENFORCED)
 
-        registerEnum(L, GateRank::E)
-        registerEnum(L, GateRank::D)
-        registerEnum(L, GateRank::C)
-        registerEnum(L, GateRank::B)
-        registerEnum(L, GateRank::A)
-        registerEnum(L, GateRank::S)
+        registerTable(L, "GateRank");
+        registerEnum(L, GateRank::E);
+        registerEnumIn(L, "GateRank", GateRank::E);
+        registerEnum(L, GateRank::D);
+        registerEnumIn(L, "GateRank", GateRank::D);
+        registerEnum(L, GateRank::C);
+        registerEnumIn(L, "GateRank", GateRank::C);
+        registerEnum(L, GateRank::B);
+        registerEnumIn(L, "GateRank", GateRank::B);
+        registerEnum(L, GateRank::A);
+        registerEnumIn(L, "GateRank", GateRank::A);
+        registerEnum(L, GateRank::S);
+        registerEnumIn(L, "GateRank", GateRank::S);
 
-        registerEnum(L, GateType::NORMAL)
-        registerEnum(L, GateType::RED)
-        registerEnum(L, GateType::DOUBLE)
+        registerTable(L, "GateType");
+        registerEnum(L, GateType::NORMAL);
+        registerEnumIn(L, "GateType", GateType::NORMAL);
+        registerEnum(L, GateType::RED);
+        registerEnumIn(L, "GateType", GateType::RED);
+        registerEnum(L, GateType::DOUBLE);
+        registerEnumIn(L, "GateType", GateType::DOUBLE)
 
 	// Use with container:addItem, container:addItemEx and possibly other functions.
 	registerEnum(L, FLAG_NOLIMIT)


### PR DESCRIPTION
## Summary
- expose `GateRank` and `GateType` enums in Lua tables to match docs
- add legacy `table.contains` helper to compat lib
- provide missing `apply_custom_attributes.lua` script for movements

## Testing
- `cmake -B build -G "Unix Makefiles"` *(fails: Could not find package configuration file provided by "fmt")*

------
https://chatgpt.com/codex/tasks/task_e_6876c5124bc08332aa604c1b6c10c7ff