### PR TITLE
Add comment for gate enum tables

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -1907,7 +1907,8 @@ void LuaScriptInterface::registerFunctions() {
 	registerEnum(L, WORLD_TYPE_PVP);
 	registerEnum(L, WORLD_TYPE_PVP_ENFORCED);
 
-	registerTable(L, "GateRank");
+        // Gate system enums
+        registerTable(L, "GateRank");
 	registerEnum(L, GateRank::E);
 	registerEnumIn(L, "GateRank", GateRank::E);
 	registerEnum(L, GateRank::D);


### PR DESCRIPTION
## Summary
- add a small comment marking the gate system enum definitions in `registerFunctions`

## Testing
- `cmake --preset default` *(fails: Could NOT find fmt)*

------
https://chatgpt.com/codex/tasks/task_e_6876e9c0773483328833fddc20a6cea3