### PR TITLE
Ensure gate enum tables exist before Lua registration

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -1909,26 +1909,27 @@ void LuaScriptInterface::registerFunctions() {
 
         // Gate system enums
         registerTable(L, "GateRank");
-	registerEnum(L, GateRank::E);
-	registerEnumIn(L, "GateRank", GateRank::E);
-	registerEnum(L, GateRank::D);
-	registerEnumIn(L, "GateRank", GateRank::D);
-	registerEnum(L, GateRank::C);
-	registerEnumIn(L, "GateRank", GateRank::C);
-	registerEnum(L, GateRank::B);
-	registerEnumIn(L, "GateRank", GateRank::B);
-	registerEnum(L, GateRank::A);
-	registerEnumIn(L, "GateRank", GateRank::A);
-	registerEnum(L, GateRank::S);
-	registerEnumIn(L, "GateRank", GateRank::S);
+        registerTable(L, "GateType");
 
-	registerTable(L, "GateType");
-	registerEnum(L, GateType::NORMAL);
-	registerEnumIn(L, "GateType", GateType::NORMAL);
-	registerEnum(L, GateType::RED);
-	registerEnumIn(L, "GateType", GateType::RED);
-	registerEnum(L, GateType::DOUBLE);
-	registerEnumIn(L, "GateType", GateType::DOUBLE);
+        registerEnum(L, GateRank::E);
+        registerEnumIn(L, "GateRank", GateRank::E);
+        registerEnum(L, GateRank::D);
+        registerEnumIn(L, "GateRank", GateRank::D);
+        registerEnum(L, GateRank::C);
+        registerEnumIn(L, "GateRank", GateRank::C);
+        registerEnum(L, GateRank::B);
+        registerEnumIn(L, "GateRank", GateRank::B);
+        registerEnum(L, GateRank::A);
+        registerEnumIn(L, "GateRank", GateRank::A);
+        registerEnum(L, GateRank::S);
+        registerEnumIn(L, "GateRank", GateRank::S);
+
+        registerEnum(L, GateType::NORMAL);
+        registerEnumIn(L, "GateType", GateType::NORMAL);
+        registerEnum(L, GateType::RED);
+        registerEnumIn(L, "GateType", GateType::RED);
+        registerEnum(L, GateType::DOUBLE);
+        registerEnumIn(L, "GateType", GateType::DOUBLE);
 
 
 	// Use with container:addItem, container:addItemEx and possibly other functions.


### PR DESCRIPTION
## Summary
- fix registerFunctions so GateRank and GateType tables are created before inserting enums

## Testing
- `cmake -B build -G Ninja` *(fails: Could not find fmtConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_6876eefdeb0c8332aed41d32ef6d14f1