### PR TITLE
Fix gate config loading

### DIFF
--- a/src/gatemanager.cpp
+++ b/src/gatemanager.cpp
@@ -122,12 +122,14 @@ Gate* GateManager::spawnGate(const Position& pos, GateRank rank, GateType type)
 
 void GateManager::loadSpawnConfig(const std::string& file)
 {
-        lua_State* L = g_luaEnvironment.getLuaState();
-        if (luaL_dofile(L, file.c_str()) != 0) {
-                std::cout << "[Error - GateManager::loadSpawnConfig] " << lua_tostring(L, -1) << std::endl;
-                lua_pop(L, 1);
-                return;
-        }
+       lua_State* L = g_luaEnvironment.getLuaState();
+       // use the script interface loader so any runtime errors are
+       // properly routed through the error handler instead of triggering
+       // a panic inside luaL_dofile
+       if (g_luaEnvironment.loadFile(file) != 0) {
+               std::cout << "[Error - GateManager::loadSpawnConfig] " << g_luaEnvironment.getLastLuaError() << std::endl;
+               return;
+       }
 
         lua_getglobal(L, "GateSpawnConfig");
         if (!lua_istable(L, -1)) {

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -1918,25 +1918,16 @@ void LuaScriptInterface::registerFunctions() {
         registerTable(L, "GateRank");
         registerTable(L, "GateType");
 
-        registerEnum(L, GateRank::E);
-        registerEnumIn(L, "GateRank", GateRank::E);
-        registerEnum(L, GateRank::D);
-        registerEnumIn(L, "GateRank", GateRank::D);
-        registerEnum(L, GateRank::C);
-        registerEnumIn(L, "GateRank", GateRank::C);
-        registerEnum(L, GateRank::B);
-        registerEnumIn(L, "GateRank", GateRank::B);
-        registerEnum(L, GateRank::A);
-        registerEnumIn(L, "GateRank", GateRank::A);
-        registerEnum(L, GateRank::S);
-        registerEnumIn(L, "GateRank", GateRank::S);
+       registerEnumIn(L, "GateRank", GateRank::E);
+       registerEnumIn(L, "GateRank", GateRank::D);
+       registerEnumIn(L, "GateRank", GateRank::C);
+       registerEnumIn(L, "GateRank", GateRank::B);
+       registerEnumIn(L, "GateRank", GateRank::A);
+       registerEnumIn(L, "GateRank", GateRank::S);
 
-        registerEnum(L, GateType::NORMAL);
-        registerEnumIn(L, "GateType", GateType::NORMAL);
-        registerEnum(L, GateType::RED);
-        registerEnumIn(L, "GateType", GateType::RED);
-        registerEnum(L, GateType::DOUBLE);
-        registerEnumIn(L, "GateType", GateType::DOUBLE);
+       registerEnumIn(L, "GateType", GateType::NORMAL);
+       registerEnumIn(L, "GateType", GateType::RED);
+       registerEnumIn(L, "GateType", GateType::DOUBLE);
 
 
 	// Use with container:addItem, container:addItemEx and possibly other functions.


### PR DESCRIPTION
## Summary
- load gate spawn config through the standard script loader to avoid Lua API panics
- avoid clobbering global names when registering gate enums

## Testing
- `cmake --build build -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_6876ff8c82d88332ad06e4b9829a8521