### PR TITLE
Fix Lua panic on gate spawn config

### DIFF
--- a/src/gatemanager.cpp
+++ b/src/gatemanager.cpp
@@ -122,6 +122,7 @@ Gate* GateManager::spawnGate(const Position& pos, GateRank rank, GateType type)
 
 void GateManager::loadSpawnConfig(const std::string& file)
 {
+       // Make sure enum tables are available before executing the config
        g_luaEnvironment.ensureGateEnums();
 
        lua_State* L = g_luaEnvironment.getLuaState();

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -17250,8 +17250,11 @@ bool LuaEnvironment::initState() {
 		return false;
 	}
 
-	luaL_openlibs(L);
-	registerFunctions();
+        luaL_openlibs(L);
+        registerFunctions();
+
+        // ensure custom enums like GateRank and GateType are present
+        ensureGateEnums();
 
 	runningEventId = EVENT_ID_USER;
 	return true;


### PR DESCRIPTION
## Summary
- ensure gate enum tables are created when Lua environment initializes
- clarify comment and call `ensureGateEnums` before loading gate spawn config

## Testing
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_68770efe6d3883328a616abd69732f25