### PR TITLE
Refactor Combat into modular helpers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,8 +5,11 @@ set(tfs_SRC
 	${CMAKE_CURRENT_LIST_DIR}/baseevents.cpp
 	${CMAKE_CURRENT_LIST_DIR}/bed.cpp
 	${CMAKE_CURRENT_LIST_DIR}/chat.cpp
-	${CMAKE_CURRENT_LIST_DIR}/combat.cpp
-	${CMAKE_CURRENT_LIST_DIR}/condition.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/combat.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/combat/AreaResolver.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/combat/DamageCalculator.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/combat/EffectApplier.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/condition.cpp
 	${CMAKE_CURRENT_LIST_DIR}/configmanager.cpp
 	${CMAKE_CURRENT_LIST_DIR}/connection.cpp
 	${CMAKE_CURRENT_LIST_DIR}/container.cpp
@@ -84,8 +87,11 @@ set(tfs_HDR
 	${CMAKE_CURRENT_LIST_DIR}/baseevents.h
 	${CMAKE_CURRENT_LIST_DIR}/bed.h
 	${CMAKE_CURRENT_LIST_DIR}/chat.h
-	${CMAKE_CURRENT_LIST_DIR}/combat.h
-	${CMAKE_CURRENT_LIST_DIR}/condition.h
+        ${CMAKE_CURRENT_LIST_DIR}/combat.h
+        ${CMAKE_CURRENT_LIST_DIR}/combat/AreaResolver.h
+        ${CMAKE_CURRENT_LIST_DIR}/combat/DamageCalculator.h
+        ${CMAKE_CURRENT_LIST_DIR}/combat/EffectApplier.h
+        ${CMAKE_CURRENT_LIST_DIR}/condition.h
 	${CMAKE_CURRENT_LIST_DIR}/configmanager.h
 	${CMAKE_CURRENT_LIST_DIR}/connection.h
 	${CMAKE_CURRENT_LIST_DIR}/const.h

--- a/src/combat/AreaResolver.cpp
+++ b/src/combat/AreaResolver.cpp
@@ -1,0 +1,51 @@
+#include "../otpch.h"
+#include "AreaResolver.h"
+#include "../combat.h"
+#include "../game.h"
+#include "../map.h"
+
+AreaResolver::AreaResolver(Game& game) : game(game) {}
+
+std::vector<Tile*> AreaResolver::getList(const MatrixArea& area, const Position& targetPos, Direction dir) const
+{
+    auto casterPos = getNextPosition(dir, targetPos);
+
+    std::vector<Tile*> vec;
+
+    auto center = area.getCenter();
+    Position tmpPos(targetPos.x - center.first, targetPos.y - center.second, targetPos.z);
+    for (uint32_t row = 0; row < area.getRows(); ++row, ++tmpPos.y) {
+        for (uint32_t col = 0; col < area.getCols(); ++col, ++tmpPos.x) {
+            if (area(row, col)) {
+                if (game.isSightClear(casterPos, tmpPos, true)) {
+                    Tile* tile = game.map.getTile(tmpPos);
+                    if (!tile) {
+                        tile = new StaticTile(tmpPos.x, tmpPos.y, tmpPos.z);
+                        game.map.setTile(tmpPos, tile);
+                    }
+                    vec.push_back(tile);
+                }
+            }
+        }
+        tmpPos.x -= area.getCols();
+    }
+    return vec;
+}
+
+std::vector<Tile*> AreaResolver::resolve(const Position& centerPos, const Position& targetPos, const AreaCombat* area) const
+{
+    if (targetPos.z >= MAP_MAX_LAYERS) {
+        return {};
+    }
+
+    if (area) {
+        return getList(area->getArea(centerPos, targetPos), targetPos, getDirectionTo(targetPos, centerPos));
+    }
+
+    Tile* tile = game.map.getTile(targetPos);
+    if (!tile) {
+        tile = new StaticTile(targetPos.x, targetPos.y, targetPos.z);
+        game.map.setTile(targetPos, tile);
+    }
+    return {tile};
+}

--- a/src/combat/AreaResolver.h
+++ b/src/combat/AreaResolver.h
@@ -1,0 +1,24 @@
+#ifndef FS_AREA_RESOLVER_H
+#define FS_AREA_RESOLVER_H
+
+#include <vector>
+#include "../position.h"
+#include "../matrixarea.h"
+
+class Game;
+class Tile;
+class AreaCombat;
+
+class AreaResolver {
+public:
+    explicit AreaResolver(Game& game);
+
+    std::vector<Tile*> resolve(const Position& centerPos, const Position& targetPos, const AreaCombat* area) const;
+
+private:
+    std::vector<Tile*> getList(const MatrixArea& area, const Position& targetPos, Direction dir) const;
+
+    Game& game;
+};
+
+#endif // FS_AREA_RESOLVER_H

--- a/src/combat/DamageCalculator.cpp
+++ b/src/combat/DamageCalculator.cpp
@@ -1,0 +1,53 @@
+#include "../otpch.h"
+#include "DamageCalculator.h"
+#include "../player.h"
+
+DamageCalculator::DamageCalculator(Game& game) : game(game) {}
+
+void DamageCalculator::applyCritical(Player* casterPlayer, CombatDamage& damage, int32_t& primaryBonus, int32_t& secondaryBonus) const
+{
+    primaryBonus = 0;
+    secondaryBonus = 0;
+    if (!damage.critical && damage.primary.type != COMBAT_HEALING && casterPlayer && damage.origin != ORIGIN_CONDITION) {
+        uint16_t chance = casterPlayer->getSpecialSkill(SPECIALSKILL_CRITICALHITCHANCE);
+        uint16_t skill = casterPlayer->getSpecialSkill(SPECIALSKILL_CRITICALHITAMOUNT);
+        if (chance > 0 && skill > 0 && uniform_random(1, 100) <= chance) {
+            primaryBonus = std::round(damage.primary.value * (skill / 10000.));
+            secondaryBonus = std::round(damage.secondary.value * (skill / 10000.));
+            damage.critical = true;
+        }
+    }
+}
+
+bool DamageCalculator::applyDamage(Creature* caster, Creature* target, CombatDamage& damage, const CombatParams& params,
+                                   int32_t primaryBonus, int32_t secondaryBonus) const
+{
+    Player* casterPlayer = caster ? caster->getPlayer() : nullptr;
+    bool playerCombatReduced = false;
+
+    if ((damage.primary.value < 0 || damage.secondary.value < 0) && caster) {
+        Player* targetPlayer = target->getPlayer();
+        if (casterPlayer && targetPlayer && casterPlayer != targetPlayer && targetPlayer->getSkull() != SKULL_BLACK) {
+            damage.primary.value /= 2;
+            damage.secondary.value /= 2;
+            playerCombatReduced = true;
+        }
+    }
+
+    if (damage.critical) {
+        damage.primary.value += playerCombatReduced ? primaryBonus / 2 : primaryBonus;
+        damage.secondary.value += playerCombatReduced ? secondaryBonus / 2 : secondaryBonus;
+        game.addMagicEffect(target->getPosition(), CONST_ME_CRITICAL_DAMAGE);
+    }
+
+    bool success = false;
+    if (damage.primary.type != COMBAT_MANADRAIN) {
+        if (game.combatBlockHit(damage, caster, target, params.blockedByShield, params.blockedByArmor, params.itemId != 0, params.ignoreResistances)) {
+            return false;
+        }
+        success = game.combatChangeHealth(caster, target, damage);
+    } else {
+        success = game.combatChangeMana(caster, target, damage);
+    }
+    return success;
+}

--- a/src/combat/DamageCalculator.h
+++ b/src/combat/DamageCalculator.h
@@ -1,0 +1,21 @@
+#ifndef FS_DAMAGE_CALCULATOR_H
+#define FS_DAMAGE_CALCULATOR_H
+
+#include "../combat.h"
+#include "../game.h"
+
+class DamageCalculator {
+public:
+    explicit DamageCalculator(Game& game);
+
+    // Prepare critical hit values and set damage.critical when triggered
+    void applyCritical(Player* casterPlayer, CombatDamage& damage, int32_t& primaryBonus, int32_t& secondaryBonus) const;
+
+    bool applyDamage(Creature* caster, Creature* target, CombatDamage& damage, const CombatParams& params,
+                     int32_t primaryBonus, int32_t secondaryBonus) const;
+
+private:
+    Game& game;
+};
+
+#endif // FS_DAMAGE_CALCULATOR_H

--- a/src/combat/EffectApplier.cpp
+++ b/src/combat/EffectApplier.cpp
@@ -1,0 +1,60 @@
+#include "../otpch.h"
+#include "EffectApplier.h"
+#include "../player.h"
+
+EffectApplier::EffectApplier(Game& game) : game(game) {}
+
+void EffectApplier::applyAfterHit(Creature* caster, Creature* target, const CombatDamage& damage,
+                                  const CombatParams& params, Player* casterPlayer,
+                                  int32_t totalDamage, size_t targetsCount) const
+{
+    if (damage.blockType == BLOCK_NONE || damage.blockType == BLOCK_ARMOR) {
+        for (const auto& condition : params.conditionList) {
+            if (caster == target || !target->isImmune(condition->getType())) {
+                Condition* conditionCopy = condition->clone();
+                if (caster) {
+                    conditionCopy->setParam(CONDITION_PARAM_OWNER, caster->getID());
+                }
+                target->addCombatCondition(conditionCopy);
+            }
+        }
+    }
+
+    if (casterPlayer && !damage.leeched && damage.primary.type != COMBAT_HEALING && damage.origin != ORIGIN_CONDITION) {
+        if (casterPlayer->getHealth() < casterPlayer->getMaxHealth()) {
+            uint16_t chance = casterPlayer->getSpecialSkill(SPECIALSKILL_LIFELEECHCHANCE);
+            uint16_t skill = casterPlayer->getSpecialSkill(SPECIALSKILL_LIFELEECHAMOUNT);
+            if (chance > 0 && skill > 0 && normal_random(1, 100) <= chance) {
+                CombatDamage leechCombat;
+                leechCombat.origin = ORIGIN_NONE;
+                leechCombat.leeched = true;
+                leechCombat.primary.value = std::ceil(totalDamage * ((skill / 10000.) + ((targetsCount - 1) * ((skill / 10000.) / 10.))) / static_cast<double>(targetsCount));
+                game.combatChangeHealth(nullptr, casterPlayer, leechCombat);
+                casterPlayer->sendMagicEffect(casterPlayer->getPosition(), CONST_ME_MAGIC_RED);
+            }
+        }
+
+        if (casterPlayer->getMana() < casterPlayer->getMaxMana()) {
+            uint16_t chance = casterPlayer->getSpecialSkill(SPECIALSKILL_MANALEECHCHANCE);
+            uint16_t skill = casterPlayer->getSpecialSkill(SPECIALSKILL_MANALEECHAMOUNT);
+            if (chance > 0 && skill > 0 && normal_random(1, 100) <= chance) {
+                CombatDamage leechCombat;
+                leechCombat.origin = ORIGIN_NONE;
+                leechCombat.leeched = true;
+                leechCombat.primary.value = std::ceil(totalDamage * ((skill / 10000.) + ((targetsCount - 1) * ((skill / 10000.) / 10.))) / static_cast<double>(targetsCount));
+                game.combatChangeMana(nullptr, casterPlayer, leechCombat);
+                casterPlayer->sendMagicEffect(casterPlayer->getPosition(), CONST_ME_MAGIC_BLUE);
+            }
+        }
+    }
+
+    if (params.dispelType == CONDITION_PARALYZE) {
+        target->removeCondition(CONDITION_PARALYZE);
+    } else {
+        target->removeCombatCondition(params.dispelType);
+    }
+
+    if (params.targetCallback) {
+        params.targetCallback->onTargetCombat(caster, target);
+    }
+}

--- a/src/combat/EffectApplier.h
+++ b/src/combat/EffectApplier.h
@@ -1,0 +1,19 @@
+#ifndef FS_EFFECT_APPLIER_H
+#define FS_EFFECT_APPLIER_H
+
+#include "../combat.h"
+#include "../game.h"
+
+class EffectApplier {
+public:
+    explicit EffectApplier(Game& game);
+
+    void applyAfterHit(Creature* caster, Creature* target, const CombatDamage& damage,
+                       const CombatParams& params, Player* casterPlayer,
+                       int32_t totalDamage, size_t targetsCount) const;
+
+private:
+    Game& game;
+};
+
+#endif // FS_EFFECT_APPLIER_H


### PR DESCRIPTION
## Summary
- split out combat helper classes: `AreaResolver`, `DamageCalculator`, `EffectApplier`
- refactor `doAreaCombat` and helper call site to use the new classes
- link new modules through CMake

## Testing
- `cmake -S . -B build`
- `cmake --build build -j 4`

------
https://chatgpt.com/codex/tasks/task_e_6877f612f6f0833282f4cbd707efa315