### PR TITLE
Fix monster level scaling and bonuses

### DIFF
--- a/src/monster.h
+++ b/src/monster.h
@@ -56,7 +56,10 @@ class Monster final : public Creature {
                 void setName(const std::string& name);
 
                 uint32_t getLevel() const;
-                void setLevel(uint32_t lvl);
+               void setLevel(uint32_t lvl);
+
+               void setMaxHealth(int32_t newMax);
+               void setHealth(int32_t newHealth);
 
 		const std::string& getNameDescription() const override;
 		void setNameDescription(const std::string& nameDescription) {


### PR DESCRIPTION
## Summary
- calculate monster level cumulatively per floor
- add helper methods for adjusting monster health
- scale monster health, speed, and damage based on level

## Testing
- `cmake -B build -S .`
- `cmake --build build -j $(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_6878326492348332894924530901e100