### PR TITLE
Adjust lost experience for monster levels

### DIFF
--- a/src/monster.h
+++ b/src/monster.h
@@ -258,9 +258,13 @@ class Monster final : public Creature {
 		bool isFriend(const Creature* creature) const;
 		bool isOpponent(const Creature* creature) const;
 
-		uint64_t getLostExperience() const override {
-			return skillLoss ? mType->info.experience : 0;
-		}
+                uint64_t getLostExperience() const override {
+                        uint64_t base = mType->info.experience;
+                        if (level > 1) {
+                                base += static_cast<uint64_t>(base * 0.08f * level);
+                        }
+                        return skillLoss ? base : 0;
+                }
 		uint16_t getLookCorpse() const override {
 			return mType->info.lookcorpse;
 		}


### PR DESCRIPTION
## Summary
- compute monster experience loss scaling with level

## Testing
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_6878528af3ac8332b0a751652d3aec49