### PR TITLE
Add adaptive Echo Golem AI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /build/ 
 /vcpkg_installed/ 
 /vc22/.vs/ 
+data/ai_memory/
+!data/ai_memory/.gitkeep

--- a/data/monster/monsters.xml
+++ b/data/monster/monsters.xml
@@ -741,4 +741,5 @@
 	<monster name="Zugurosh" file="monsters/zugurosh.xml" />
 	<monster name="Zulazza the Corruptor" file="monsters/zulazza_the_corruptor.xml" />
 	<monster name="Zushuka" file="monsters/zushuka.xml" />
+        <monster name="Echo Golem" file="monsters/echo_golem.xml" />
 </monsters>

--- a/data/monster/monsters/echo_golem.xml
+++ b/data/monster/monsters/echo_golem.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<monster name="Echo Golem" nameDescription="an echo golem" race="undead" experience="180" speed="200" manacost="590">
+    <health now="300" max="300" />
+    <look type="67" corpse="6005" />
+    <targetchange interval="4000" chance="10" />
+
+    <flags>
+        <flag attackable="1" />
+        <flag hostile="1" />
+        <flag summonable="0" />
+        <flag convinceable="0" />
+        <flag pushable="0" />
+        <flag canpushitems="1" />
+        <flag canpushcreatures="1" />
+        <flag targetdistance="1" />
+    </flags>
+
+    <attacks>
+        <attack name="melee" interval="2000" min="0" max="-110" />
+    </attacks>
+
+    <defenses armor="30" defense="30" />
+
+    <script>
+        <event name="EchoGolem" />
+    </script>
+
+    <loot>
+        <item name="gold coin" countmax="50" chance="50000" />
+        <item name="small stone" countmax="4" chance="13000" />
+    </loot>
+</monster>

--- a/data/scripts/creaturescripts/echo_golem.lua
+++ b/data/scripts/creaturescripts/echo_golem.lua
@@ -1,0 +1,21 @@
+-- Monster specific wrapper delegating to the shared EchoAI
+local EchoAI = dofile('data/scripts/monsters/echo_base.lua')
+local echoEvent = CreatureEvent('EchoGolem')
+
+echoEvent.onSpawn = function(monster, position, startup, artificial)
+    return EchoAI.onSpawn(monster, position, startup, artificial)
+end
+
+echoEvent.onThink = function(monster, interval)
+    return EchoAI.onThink(monster, interval)
+end
+
+echoEvent.onHealthChange = function(monster, attacker, primaryDamage, primaryType, secondaryDamage, secondaryType, origin)
+    return EchoAI.onHealthChange(monster, attacker, primaryDamage, primaryType, secondaryDamage, secondaryType, origin)
+end
+
+echoEvent.onDeath = function(monster, corpse, killer, mostDamageKiller, lastHitUnjustified, mostDamageUnjustified)
+    return EchoAI.onDeath(monster, corpse, killer, mostDamageKiller, lastHitUnjustified, mostDamageUnjustified)
+end
+
+echoEvent:register()

--- a/data/scripts/monsters/echo_base.lua
+++ b/data/scripts/monsters/echo_base.lua
@@ -1,0 +1,82 @@
+-- Shared adaptive AI for echo monsters
+-- Stores persistent data in JSON files per monster name.
+local EchoAI = {}
+
+-- storage keys
+EchoAI.STORAGE_DEATHS = 8000
+EchoAI.STORAGE_LAST_HIT = 8001
+EchoAI.STORAGE_STATE = 8002
+EchoAI.memoryDir = 'data/ai_memory'
+
+local function getFile(monster)
+    local name = monster:getName():lower():gsub('%s+', '_')
+    return string.format('%s/%s.json', EchoAI.memoryDir, name)
+end
+
+local function loadMemory(monster)
+    local f = io.open(getFile(monster), 'r')
+    if f then
+        local t = json.decode(f:read('*a')) or {}
+        f:close()
+        monster.memory = t
+    else
+        monster.memory = {}
+    end
+    monster.memory.deaths = monster.memory.deaths or 0
+    monster.memory.lastKillType = monster.memory.lastKillType or -1
+end
+
+local function saveMemory(monster)
+    local f = io.open(getFile(monster), 'w')
+    if f then
+        f:write(json.encode(monster.memory))
+        f:close()
+    end
+end
+
+function EchoAI.onSpawn(monster, position, startup, artificial)
+    loadMemory(monster)
+    monster:setStorageValue(EchoAI.STORAGE_DEATHS, monster.memory.deaths)
+    monster:setStorageValue(EchoAI.STORAGE_LAST_HIT, monster.memory.lastKillType)
+    monster:setStorageValue(EchoAI.STORAGE_STATE, 0)
+    return true
+end
+
+function EchoAI.onThink(monster, interval)
+    local lastKill = monster.memory.lastKillType
+    local state = monster:getStorageValue(EchoAI.STORAGE_STATE)
+
+    if lastKill == COMBAT_FIREDAMAGE and state ~= 1 then
+        monster:changeSpeed(-20)
+        monster:say('Fire will not burn me again!', TALKTYPE_MONSTER_SAY)
+        monster:setStorageValue(EchoAI.STORAGE_STATE, 1)
+    elseif lastKill == COMBAT_ICEDAMAGE and state ~= 2 then
+        monster:changeSpeed(20)
+        monster:say('I adapted to the cold.', TALKTYPE_MONSTER_SAY)
+        monster:setStorageValue(EchoAI.STORAGE_STATE, 2)
+    end
+
+    if monster.memory.deaths >= 3 and monster:getStorageValue(EchoAI.STORAGE_STATE) ~= 3 then
+        monster:say('I return stronger!', TALKTYPE_MONSTER_YELL)
+        monster:changeSpeed(30)
+        monster:setStorageValue(EchoAI.STORAGE_STATE, 3)
+    end
+    return true
+end
+
+function EchoAI.onHealthChange(monster, attacker, primaryDamage, primaryType, secondaryDamage, secondaryType, origin)
+    if attacker then
+        monster.memory.lastAttackerId = attacker:getId()
+    end
+    monster:setStorageValue(EchoAI.STORAGE_LAST_HIT, primaryType)
+    return primaryDamage, primaryType, secondaryDamage, secondaryType
+end
+
+function EchoAI.onDeath(monster, corpse, killer, mostDamage, lastHitUnjustified, mostDamageUnjustified)
+    monster.memory.deaths = monster.memory.deaths + 1
+    monster.memory.lastKillType = monster:getStorageValue(EchoAI.STORAGE_LAST_HIT)
+    saveMemory(monster)
+    return true
+end
+
+return EchoAI


### PR DESCRIPTION
## Summary
- add reusable monster AI script `echo_base.lua`
- create `echo_golem.lua` wrapper that hooks the AI to monster events
- define `echo_golem.xml` monster and register AI event
- include new monster entry in `monsters.xml`
- store AI memory under `data/ai_memory` and ignore it by default

## Testing
- `luac -p data/scripts/monsters/echo_base.lua`
- `luac -p data/scripts/creaturescripts/echo_golem.lua`
- `apt-get install -y lua5.3`

------
https://chatgpt.com/codex/tasks/task_e_687853ac25b88332879f46f67ed54401