### PR TITLE
Add monster level spawn example

### DIFF
--- a/docs/monster_level_scaling.md
+++ b/docs/monster_level_scaling.md
@@ -13,6 +13,21 @@ Monsters gain levels based on their spawn depth in the map. Deeper floors create
 
 Example: with the default rules a monster spawned on floor `Z=12` falls under the third rule. It spawns around level **51–60** and, with `monsterBonusLoot = 0.04`, yields roughly **204%** additional loot.
 
+## Implementation Example
+
+`Spawn::spawnMonster()` assigns the level based on the creature's Z-floor. The formula adds ten levels for every floor below `Z=8`:
+
+```cpp
+int baseZ = 8;
+int floorOffset = std::abs(pos.getZ() - baseZ);
+int minLevel = (floorOffset * 10) + 1;
+int maxLevel = minLevel + 9;
+uint32_t level = static_cast<uint32_t>(uniform_random(minLevel, maxLevel));
+monster_ptr->setLevel(level);
+```
+
+For instance, a monster spawned on `Z=10` (two floors below the base) will roll a level in the **21–30** range.
+
 ## Using the Level in Scripts
 
 The level is exposed to Lua as `monster:getLevel()`:


### PR DESCRIPTION
## Summary
- document how `Spawn::spawnMonster()` sets a random level per Z-floor
- show code snippet and example range in the monster level scaling guide

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68785c12192c83329e799a24813c4cdf