### PR TITLE
Fix Echo Golem AI registration

### DIFF
--- a/data/events/events.xml
+++ b/data/events/events.xml
@@ -42,6 +42,6 @@
 	<event class="Player" method="onSpellCheck" enabled="0" />
 
 	<!-- Monster methods -->
-	<event class="Monster" method="onDropLoot" enabled="1" />
-	<event class="Monster" method="onSpawn" enabled="0" />
+    <event class="Monster" method="onDropLoot" enabled="1" />
+    <event class="Monster" method="onSpawn" enabled="1" />
 </events>

--- a/data/scripts/creaturescripts/echo_golem.lua
+++ b/data/scripts/creaturescripts/echo_golem.lua
@@ -2,10 +2,6 @@
 local EchoAI = dofile('data/scripts/monsters/echo_base.lua')
 local echoEvent = CreatureEvent('EchoGolem')
 
-echoEvent.onSpawn = function(monster, position, startup, artificial)
-    return EchoAI.onSpawn(monster, position, startup, artificial)
-end
-
 echoEvent.onThink = function(monster, interval)
     return EchoAI.onThink(monster, interval)
 end

--- a/data/scripts/eventcallbacks/monster/echo_golem_spawn.lua
+++ b/data/scripts/eventcallbacks/monster/echo_golem_spawn.lua
@@ -1,0 +1,11 @@
+local EchoAI = dofile('data/scripts/monsters/echo_base.lua')
+local event = Event()
+
+function event.onSpawn(self, position, startup, artificial)
+    if self:getName():lower() ~= 'echo golem' then
+        return true
+    end
+    return EchoAI.onSpawn(self, position, startup, artificial)
+end
+
+event:register()


### PR DESCRIPTION
## Summary
- handle Echo Golem spawn through `Event` callbacks instead of `CreatureEvent`
- enable monster `onSpawn` callbacks
- remove invalid `onSpawn` registration

## Testing
- `git commit -m "Fix Echo Golem AI registration"`


------
https://chatgpt.com/codex/tasks/task_e_687865727dc08332929c995765eb8ebd