### PR TITLE
Fix custom attribute movement script path

### DIFF
--- a/data/movements/scripts/apply_custom_attributes.lua
+++ b/data/movements/scripts/apply_custom_attributes.lua
@@ -1,4 +1,4 @@
-function onEquipCustomAttributes(player, item, slot, isCheck)
+function onEquip(player, item, slot, isCheck)
     if isCheck then
         return true
     end
@@ -12,7 +12,7 @@ function onEquipCustomAttributes(player, item, slot, isCheck)
     return true
 end
 
-function onDeEquipCustomAttributes(player, item, slot, isCheck)
+function onDeEquip(player, item, slot, isCheck)
     if isCheck then
         return true
     end


### PR DESCRIPTION
## Summary
- move the custom attribute script into `data/movements/scripts`
- rename hooks inside the script to `onEquip` and `onDeEquip`

## Testing
- `make -C build`

------
https://chatgpt.com/codex/tasks/task_e_68786b02213083328e4e5383aa667b54