### PR TITLE
Add boost-numeric-conversion to vcpkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Nexus
+
+## Building
+
+This project uses [vcpkg](https://github.com/microsoft/vcpkg) to manage C++ dependencies. Configure the build with CMake and the vcpkg toolchain, for example:
+
+```bash
+cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake
+cmake --build build
+```
+
+The dependency list in `vcpkg.json` includes **boost-numeric-conversion** and **boost-algorithm**, so ensure these ports are available in your vcpkg installation before configuring.

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,12 +5,14 @@
 	 "boost-asio",
      "boost-iostreams",
 	 "boost-locale",
-     "boost-lockfree",
-     "boost-system",
-     "boost-variant",
-     "fmt",
-	 "openssl",
-     "pugixml"
+        "boost-lockfree",
+        "boost-system",
+        "boost-variant",
+        "boost-numeric-conversion",
+        "boost-algorithm",
+        "fmt",
+        "openssl",
+        "pugixml"
    ],
 
    "features": {


### PR DESCRIPTION
## Summary
- include `boost-algorithm` dependency in vcpkg.json
- note `boost-algorithm` alongside numeric conversion in README

## Testing
- `cmake -S . -B build`
- `cmake --build build -j $(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_687876ef5ec8833292a5beda8b73ab4e