### PR TITLE
Fix loot creation param names

### DIFF
--- a/data/scripts/eventcallbacks/monster/default_onDropLoot.lua
+++ b/data/scripts/eventcallbacks/monster/default_onDropLoot.lua
@@ -25,7 +25,7 @@ event.onDropLoot = function(self, corpse)
                         if bonus > 0 then
                                 chance = math.min(100000, chance + math.floor(chance * bonus / 100))
                         end
-                        local item = corpse:createLootItem({itemid = entry.itemid, countmax = entry.countmax, chance = chance})
+                        local item = corpse:createLootItem({itemId = entry.itemId, maxCount = entry.maxCount, chance = chance})
                         if not item then
                                 print("[Warning] DropLoot: Could not add loot item to corpse.")
                         end


### PR DESCRIPTION
## Summary
- use correct itemId and maxCount keys when creating loot in default Monster event

## Testing
- `luac -p data/scripts/eventcallbacks/monster/default_onDropLoot.lua`
- `apt-get update`
- `apt-get install -y lua5.3`


------
https://chatgpt.com/codex/tasks/task_e_6878a9a57864833281618e9d2061f5a9